### PR TITLE
replaces getMemberById with retrieveMembersByIds

### DIFF
--- a/src/main/java/de/progen_bot/commands/moderator/MuteList.java
+++ b/src/main/java/de/progen_bot/commands/moderator/MuteList.java
@@ -2,6 +2,7 @@ package de.progen_bot.commands.moderator;
 
 import java.awt.Color;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 import de.progen_bot.command.CommandHandler;
@@ -30,14 +31,13 @@ public class MuteList extends CommandHandler {
                     .setColor(Color.ORANGE);
             int[] count = { 1 };
 
-            List<Long> idList = mutes.stream().map(mute -> Long.parseLong(mute.getVictimId()))
-                    .collect(Collectors.toList());
+            Map<Long, String> muteMap = mutes.stream()
+                    .collect(Collectors.toMap(mute -> Long.parseLong(mute.getVictimId()), MuteData::getReason));
 
-            event.getGuild().retrieveMembersByIds(idList).onSuccess(members -> {
+            event.getGuild().retrieveMembersByIds(muteMap.keySet()).onSuccess(members -> {
                 members.forEach(member -> {
                     sb.append(count[0]).append('.').append(' ')
-                            .append(member.getAsMention() + " " + new MuteDao().getMute(member.getId()).getReason())
-                            .append('\n');
+                            .append(member.getAsMention() + " " + muteMap.get(member.getIdLong())).append('\n');
                     count[0]++;
                 });
                 event.getTextChannel().sendMessage(eb.setDescription(sb.toString()).build()).queue();

--- a/src/main/java/de/progen_bot/commands/moderator/MuteList.java
+++ b/src/main/java/de/progen_bot/commands/moderator/MuteList.java
@@ -2,6 +2,7 @@ package de.progen_bot.commands.moderator;
 
 import java.awt.Color;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import de.progen_bot.command.CommandHandler;
 import de.progen_bot.command.CommandManager;
@@ -29,14 +30,18 @@ public class MuteList extends CommandHandler {
                     .setColor(Color.ORANGE);
             int[] count = { 1 };
 
-            mutes.forEach(mute -> {
-                sb.append(count[0]).append('.').append(' ').append(
-                        event.getGuild().getMemberById(mute.getVictimId()).getAsMention() + " " + mute.getReason())
-                        .append('\n');
-                count[0]++;
-            });
+            List<Long> idList = mutes.stream().map(mute -> Long.parseLong(mute.getVictimId()))
+                    .collect(Collectors.toList());
 
-            event.getTextChannel().sendMessage(eb.setDescription(sb.toString()).build()).queue();
+            event.getGuild().retrieveMembersByIds(idList).onSuccess(members -> {
+                members.forEach(member -> {
+                    sb.append(count[0]).append('.').append(' ')
+                            .append(member.getAsMention() + " " + new MuteDao().getMute(member.getId()).getReason())
+                            .append('\n');
+                    count[0]++;
+                });
+                event.getTextChannel().sendMessage(eb.setDescription(sb.toString()).build()).queue();
+            });
         } else {
             event.getChannel().sendMessage(super.messageGenerators.generateErrorMsg("No mutes found.")).queue();
         }


### PR DESCRIPTION
to avoid nullPointerException

## Requirements for Contributing

* [x] The changed and/or added Code should be documented and understandable.
* [x] The changed and/or added Code should follow the Code Conventions.

## Type of the Pull Request
* [x] Bugfix
* [ ] Feature change
* [ ] Documentation change
* [ ] Something different

## Description of the Changes
Replaces getMemberById with retrieveMembersByIds to avoid the NullPointerException when the member is not cached.

## References

## Dependencies
