### PR TITLE
refractors channel creation and adds null check

### DIFF
--- a/src/main/java/de/progen_bot/listeners/PrivateVoice.java
+++ b/src/main/java/de/progen_bot/listeners/PrivateVoice.java
@@ -14,14 +14,14 @@ public class PrivateVoice extends ListenerAdapter {
 
         if (!event.getChannelLeft().getName().contains(PRIVATEVOICECHANNELPREFIX)) return;
         if (event.getChannelLeft().getMembers().size() == 0) {
-            event.getChannelLeft().delete().complete();
+            event.getChannelLeft().delete().queue();
         }
     }
 
     public void onGuildVoiceMove(GuildVoiceMoveEvent event) {
         if (!event.getChannelLeft().getName().contains(PRIVATEVOICECHANNELPREFIX)) return;
         if (event.getChannelLeft().getMembers().size() == 0) {
-            event.getChannelLeft().delete().complete();
+            event.getChannelLeft().delete().queue();
         }
     }
 }


### PR DESCRIPTION
removes the NPE when no categoryid is set

## Requirements for Contributing

* [x] The changed and/or added Code should be documented and understandable.
* [x] The changed and/or added Code should follow the Code Conventions.

## Type of the Pull Request
* [x] Bugfix
* [ ] Feature change
* [ ] Documentation change
* [ ] Something different

## Description of the Changes
- Refractors the channel creation. Using Consumer instead of complete.
- Adds a better help text.


## References
Fixes #49 

## Dependencies

